### PR TITLE
Bugs/user timeline

### DIFF
--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -16,15 +16,6 @@
         <span class="display-page"> Page @Model.CurrentPage/@Model.TotalPageCount </span>
     </header>
 
-    @*
-        TODO - show cheeps based on your login and follower
-        if 
-            (User.Identity?.IsAuthenticated == true && cheep.AuthorName == User.Identity.Name)
-                your own timeline = display your cheeps + all your followers cheeps
-        else
-            display cheeps of the user you are visiting only
-    *@
-    
     @if (Model.Cheeps.Any())
     {
         <partial name="Partials/_CheepContext" model="Model"/>

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using Chirp.Core;
 using Chirp.Core.DTOs;
 using Chirp.Infrastructure.Entities;
@@ -92,7 +93,7 @@ public class UserTimelineModel : BasePageModel
         }
         
         Cheeps = Cheeps
-            .OrderByDescending(c => c.TimeStamp)
+            .OrderByDescending(c => DateTime.ParseExact(c.TimeStamp, "MM/dd/yyyy HH:mm:ss", CultureInfo.InvariantCulture))
             .Skip((CurrentPage - 1) * MaxCheepsPerPage)
             .Take(MaxCheepsPerPage);
         

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -28,7 +28,6 @@ public class UserTimelineModel : BasePageModel
     public Dictionary<string, bool> FollowStatus { get; set; } = new Dictionary<string, bool>();
     public int TotalFollowerCheepCount { get; set; }
 
-
     [BindProperty, StringLength(160), Required]
     public string? CheepMessage { get; set; }
 
@@ -55,7 +54,6 @@ public class UserTimelineModel : BasePageModel
             {
                 return RedirectToPage("/Public");
             }
-            
         }
         
         //The following if statement has been made with the help of CHAT-GPT
@@ -97,8 +95,7 @@ public class UserTimelineModel : BasePageModel
             .Skip((CurrentPage - 1) * MaxCheepsPerPage)
             .Take(MaxCheepsPerPage);
         
-        // ----------------------------------------------------------
-
+        // Pagination
         TotalPageCount = GetTotalPages(author) == 0 ? 1 : GetTotalPages(author);
         CalculatePagination();
 

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Chirp.Core;
 using Chirp.Core.DTOs;
+using Chirp.Infrastructure.Entities;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 
@@ -24,6 +25,7 @@ public class UserTimelineModel : BasePageModel
     public string? RouteName { get; set; }
     public int CheepMaxLength { get; set; } = 160;
     public Dictionary<string, bool> FollowStatus { get; set; } = new Dictionary<string, bool>();
+    public int TotalFollowerCheepCount { get; set; }
 
 
     [BindProperty, StringLength(160), Required]
@@ -73,7 +75,9 @@ public class UserTimelineModel : BasePageModel
             {
                 foreach (var authorDto in Followers)
                 {
-                    Cheeps = Cheeps.Union(_cheepRepository.GetCheepsFromAuthor(authorDto.Name));
+                    var followerCheeps = _cheepRepository.GetCheepsFromAuthor(authorDto.Name);
+                    Cheeps = Cheeps.Union(followerCheeps);
+                    TotalFollowerCheepCount += followerCheeps.Count();
                 }
             }   
             foreach (var cheep in Cheeps)
@@ -105,7 +109,7 @@ public class UserTimelineModel : BasePageModel
 
     public int GetTotalPages(string author)
     {
-        int totalCheeps = _cheepRepository.GetCheepsFromAuthor(author).Count();
+        int totalCheeps = _cheepRepository.GetCheepsFromAuthor(author).Count() + TotalFollowerCheepCount;
         return (int)Math.Ceiling((double)totalCheeps / MaxCheepsPerPage);
     }
 


### PR DESCRIPTION
Fixed UserTimeline. 

Followers cheeps number count is now added on top of your own cheep count. Pagination now calculates correctly, and will display the actual number of pages, instead of just 1, and the pagination buttons are therefore also shown.

The order which cheeps are ordered now properly displays the correct order.